### PR TITLE
Added Android Build Tools 30.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -123,8 +123,10 @@ RUN echo "Installing sdk tools ${ANDROID_SDK_TOOLS_VERSION}" && \
         "platform-tools" > /dev/null && \
     echo "Installing build tools " && \
     yes | "$ANDROID_HOME"/tools/bin/sdkmanager \
+        "build-tools;30.0.3" \
         "build-tools;29.0.2" \
-        "build-tools;28.0.3" "build-tools;28.0.2" \
+        "build-tools;28.0.3" \
+        "build-tools;28.0.2" \
         "build-tools;27.0.3" > /dev/null && \
     echo "Installing extras " && \
     yes | "$ANDROID_HOME"/tools/bin/sdkmanager \


### PR DESCRIPTION
Added Android build tools v30.0.3, which is needed for the new Bubblewrap.