### PR TITLE
feat: improve sdkmanager install for build tools and platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -458,12 +458,15 @@ WORKDIR ${FINAL_DIRWORK}
 
 FROM pre-minimal as minimal-plus
 
-ARG BUILD_TOOLS="build-tools;33.0.2"
+# https://developer.android.com/tools/releases/build-tools
+ARG BUILD_TOOLS="build-tools;34.0.0"
+# targetSdkVersion on bubblewrap https://github.com/GoogleChromeLabs/bubblewrap/blob/main/packages/core/template_project/app/build.gradle#L59
+ARG PLATFORMS="platforms;android-35"
 ARG NODE_VERSION="18.x"
 
 RUN echo "installing: ${BUILD_TOOLS}" && \
     . /etc/jdk.env && \
-    yes | ${ANDROID_SDK_MANAGER} ${DEBUG:+--verbose} --install "${BUILD_TOOLS}" > /dev/null
+    yes | ${ANDROID_SDK_MANAGER} ${DEBUG:+--verbose} --install "${BUILD_TOOLS}" "${PLATFORMS}" > /dev/null
 
 RUN curl -sL -k https://deb.nodesource.com/setup_${NODE_VERSION} | bash - > /dev/null
 RUN apt-get install -qq nodejs > /dev/null && \


### PR DESCRIPTION
## Context

A new container based on this image is going to have **no platforms** and outdated version of build-tools, example:

![old](https://github.com/user-attachments/assets/95c1d8a6-f17f-4c5f-b601-5499583e3d6a)

Above red line is the initial files/folders before any request, and below red line is once you request to build a new app, its going to download and install the required versions for the latest bubblewrap. See it has 2 different build tools, the v33 that is installed because of this Dockerfile, and the v34 required for the bubblewrap + platforms during execution time.

## Intermittent bug

In PWABuilder there is one intermittent issue causing the request to fail because of `Failed to find target with hash string 'android-35'` ([see](https://github.com/pwa-builder/PWABuilder/issues/4787))

I don't have context if it's related to an old container running, or if it can be related to a new container failing to download and install, so this PR also includes a possible fix for this.

## New result

Again above red line is a new container without request and below is after request.

![new](https://github.com/user-attachments/assets/adf23358-1f3e-453c-ae0d-32b0577fa982)

It should speed up the success rate and performance since it doesn't need to install at execution time for a new container.